### PR TITLE
Fixed "Cars in Limbo" Bug

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -178,6 +178,10 @@ end
 AddEventHandler('onMySQLReady', function()
 
 	MySQL.Sync.execute("UPDATE owned_vehicles SET state=true WHERE state=false", {})
+	-- You have two choices with this. Either you need to add the following:
+        MySQL.Sync.execute("UPDATE owned_vehicles SET stored=true WHERE stored=false", {})
+	-- Or you need to remove this entire event handler and leave both the state and stored values alone
+	-- Otherwise you cause vehicles that have been destroyed, to be left in a "limbo" if a server restart occurs.
 
 end)
 -- Fin Fonction qui change les etats sorti en rentré lors d'un restart


### PR DESCRIPTION
If you restart the server after an owned vehicle has been destroyed / impounded, the vehicle will become inaccessible. You can't return it to the garage, or pull it from the garage. This fixes that.